### PR TITLE
fix: consider pattern that not exist specifiers

### DIFF
--- a/lib/rules/use-name-space-import.ts
+++ b/lib/rules/use-name-space-import.ts
@@ -85,7 +85,10 @@ export = createRule<[Options], MessageIds>({
         node: TSESTree.ImportDeclaration
       ) {
         // Exclude name space import
-        if (node.specifiers[0].type === AST_NODE_TYPES.ImportNamespaceSpecifier)
+        if (
+          node.specifiers.length === 0 ||
+          node.specifiers[0].type === AST_NODE_TYPES.ImportNamespaceSpecifier
+        )
           return;
 
         if (

--- a/tests/lib/rules/use-name-space-import.spec.ts
+++ b/tests/lib/rules/use-name-space-import.spec.ts
@@ -18,6 +18,9 @@ tester.run("use-name-space-import", rule, {
       code: "import * as React from 'react';",
     },
     {
+      code: "import 'minireset.css';",
+    },
+    {
       code: "import React from 'react';",
       options: [{ allowNotNameSpaceImportModules: ["react"] }],
     },


### PR DESCRIPTION
# What
- consider pattern that not exist specifiers

# Why
- To pass this pattern `import 'minireset.css';`