### PR TITLE
feat(no-multiple-named-imports): only check member that has type ImportSpecifier

### DIFF
--- a/docs/rules/no-multiple-named-imports.md
+++ b/docs/rules/no-multiple-named-imports.md
@@ -20,6 +20,7 @@ import { FC, FunctionComponent } from "react";
 /*eslint @hrbrain/no-multiple-named-imports: "error"*/
 
 import { FC } from "react";
+import defaultExportMember, { member1 } from "module";
 ```
 
 ## 🔧 Options

--- a/docs/rules/no-multiple-named-imports.md
+++ b/docs/rules/no-multiple-named-imports.md
@@ -12,6 +12,7 @@ Don't imports as named import from a module
 /*eslint @hrbrain/no-multiple-named-imports: "error"*/
 
 import { FC, FunctionComponent } from "react";
+import defaultExportMember, { member1, member2 } from "module";
 ```
 
 ### 👍

--- a/lib/rules/no-multiple-named-imports.ts
+++ b/lib/rules/no-multiple-named-imports.ts
@@ -3,7 +3,19 @@
 // ------------------------------------------------------------------------------
 
 import { createRule } from "../util";
-import { TSESTree } from "@typescript-eslint/experimental-utils";
+import {
+  TSESTree,
+  AST_NODE_TYPES,
+} from "@typescript-eslint/experimental-utils";
+
+// ------------------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------------------
+
+const countImportSpecifier = (node: TSESTree.ImportDeclaration) =>
+  node.specifiers.filter(
+    (specifier) => specifier.type === AST_NODE_TYPES.ImportSpecifier
+  ).length;
 
 // ------------------------------------------------------------------------------
 // Settings of createRule
@@ -38,14 +50,16 @@ export = createRule<[], MessageIds>({
       "ImportDeclaration[specifiers.length>1]"(
         node: TSESTree.ImportDeclaration
       ) {
-        context.report({
-          node,
-          loc: node.loc,
-          messageId: "noMultipleNamedImports",
-          data: {
-            moduleName: node.source.value,
-          },
-        });
+        if (countImportSpecifier(node) >= 2) {
+          context.report({
+            node,
+            loc: node.loc,
+            messageId: "noMultipleNamedImports",
+            data: {
+              moduleName: node.source.value,
+            },
+          });
+        }
       },
     };
   },

--- a/tests/lib/rules/no-multiple-named-imports.spec.ts
+++ b/tests/lib/rules/no-multiple-named-imports.spec.ts
@@ -19,11 +19,22 @@ tester.run("no-multiple-named-imports", rule, {
       import { FC } from 'react';
     `,
     },
+    {
+      code: `
+      import defaultExportMember, {member1} from 'module';
+    `,
+    },
   ],
   invalid: [
     {
       code: `
       import { FC, FunctionComponent } from 'react';
+      `,
+      errors: [{ messageId: "noMultipleNamedImports" }],
+    },
+    {
+      code: `
+      import defaultExportMember, {member1, module2} from 'module';
       `,
       errors: [{ messageId: "noMultipleNamedImports" }],
     },


### PR DESCRIPTION
fix #20 