### PR TITLE
Publish package to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+      - name: setup Node to publish to GitHub Packages
+        uses: actions/setup-node@v1
+        with:
+          registry-url: 'https://npm.pkg.github.com'
+          node-version: '12.x'
+
+      - name: publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,6 @@ jobs:
           node-version: '12.x'
 
       - name: publish to GitHub Packages
-        run: npm publish
+        run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I'd like to use this package (`@hrbrain/eslint-plugin`) and private package (`@hrbrain/xxx`) hosted by GitHub Packages. 

As of now, I think we can't fetch packages with the same scope name from different repositories.

So I try to publish this package to GitHub Packages to resolve this issue.